### PR TITLE
add jsx-no-logical-operators rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,13 +3,15 @@
 module.exports = {
   rules: {
     'never-device-emitter-remove-all': require('./lib/rules/never-device-emitter-remove-all'),
-    'no_disable_yellow_box': require('./lib/rules/no_disable_yellow_box')
+    'no_disable_yellow_box': require('./lib/rules/no_disable_yellow_box'),
+    'jsx-no-logical-operators': require('./lib/rules/jsx-no-logical-operators')
   },
   configs: {
     recommended: {
       rules: {
         'never-device-emitter-remove-all': 2,
-        'no_disable_yellow_box': 2
+        'no_disable_yellow_box': 2,
+        'jsx-no-logical-operators': 0
       }
     }
   }

--- a/lib/rules/jsx-no-logical-operators.js
+++ b/lib/rules/jsx-no-logical-operators.js
@@ -1,0 +1,77 @@
+/**
+ * @fileoverview Disallows && and || operators in JSX
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+const NODE_TYPES = {
+  JSXExpressionContainer: 'JSXExpressionContainer',
+};
+
+const EXPRESSION_TYPES = {
+  LogicalExpression: 'LogicalExpression',
+};
+
+const DISALLOW_OPERATORS = {
+  and: '\\&\\&',
+  or: '\\|\\|',
+};
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'No && and || operators in JSX',
+      category: 'Stylistic Issues',
+      recommended: false,
+    },
+    fixable: null,
+    schema: [
+      {
+        'type': 'object',
+        'properties': {
+          'and': {
+            'type': 'boolean',
+            'default': false,
+          },
+          'or': {
+            'type': 'boolean',
+            'default': false,
+          },
+        },
+        'additionalProperties': false,
+      },
+    ],
+  },
+
+  create: function (context) {
+    const operators = context.options && context.options[0];
+    const includedOperators = operators ?
+      Object.keys(operators).reduce((acc, opt) => operators[opt] && DISALLOW_OPERATORS[opt] ? [...acc, DISALLOW_OPERATORS[opt]] : acc, []) :
+      Object.values(DISALLOW_OPERATORS);
+    const disallowOperatorsRegex = new RegExp(`^(${includedOperators.join('|')})$`);
+
+    return {
+      JSXElement: (node) => {
+        const jsxExpressionContainers = node.children.filter(({type}) => NODE_TYPES[type]);
+
+        if (jsxExpressionContainers.length) {
+          jsxExpressionContainers.forEach((item) => {
+            if (item.expression.type === EXPRESSION_TYPES.LogicalExpression && !!item.expression.operator.match(disallowOperatorsRegex)) {
+              context.report({
+                node: item.expression,
+                message: `Unexpected usage of ${RegExp.$1} operator.`,
+              });
+            }
+          });
+        }
+      },
+    }
+  },
+};

--- a/tests/rules/jsx-no-logical-operators.js
+++ b/tests/rules/jsx-no-logical-operators.js
@@ -1,0 +1,42 @@
+/**
+ * @fileoverview Disallows && and || operators in JSX
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require('../../lib/rules/jsx-no-logical-operators'),
+
+  RuleTester = require('eslint').RuleTester;
+
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester({parserOptions: {ecmaVersion: 6, ecmaFeatures: {jsx: true}}});
+ruleTester.run('jsx-no-logical-operators', rule, {
+
+  valid: [
+    '<component>{true ? 1 : null}</component>',
+    '<component prop={true && 1}>{2}</component>',
+    '<component>{true && 1 ? 1 : 2}</component>',
+  ],
+
+  invalid: [
+    {
+      code: '<component>{true && 1}</component>',
+      errors: [{
+        messageId: 'Unexpected usage of && operator.',
+      }],
+    },
+    {
+      code: '<component>{true || 1}</component>',
+      errors: [{
+        messageId: 'Unexpected usage of || operator.',
+      }],
+    },
+  ],
+});


### PR DESCRIPTION
Disallows && and/or || operators in JSX
Preventing unexpected output in case `<foo>{bar.length && ...}</foo>`
No exceptions in RN non-text components `<View>{maybeEmptyString && ...}</View>`